### PR TITLE
Added temperature settings

### DIFF
--- a/apps/mcmc_gw_tool_v2.cpp
+++ b/apps/mcmc_gw_tool_v2.cpp
@@ -685,7 +685,7 @@ int main(int argc, char *argv[])
 	//bayesship::probabilityFn *logp = new logPriorStandard_D(&PD);
 	std::cout<<"Running uncorrelated sampler "<<std::endl;
 	bayesship::bayesshipSampler *sampler = PTMCMC_MH_dynamic_PT_alloc_uncorrelated_GW_v2( 
-			dimension, samples, ensembleSize, ensembleN, &default_temp_set,
+			dimension, samples, ensembleSize, ensembleN,
 			 initialPosition,ensembleInitialPosition,swapProb, 
 			 burnIterations, burnPriorIterations,priorIterations, writePriorData,max_chunk_size, (double **)nullptr,
 			logp,threads, pool,detector_N, 

--- a/apps/mcmc_gw_tool_v2.cpp
+++ b/apps/mcmc_gw_tool_v2.cpp
@@ -685,7 +685,7 @@ int main(int argc, char *argv[])
 	//bayesship::probabilityFn *logp = new logPriorStandard_D(&PD);
 	std::cout<<"Running uncorrelated sampler "<<std::endl;
 	bayesship::bayesshipSampler *sampler = PTMCMC_MH_dynamic_PT_alloc_uncorrelated_GW_v2( 
-			dimension, samples, ensembleSize, ensembleN, 
+			dimension, samples, ensembleSize, ensembleN, &default_temp_set,
 			 initialPosition,ensembleInitialPosition,swapProb, 
 			 burnIterations, burnPriorIterations,priorIterations, writePriorData,max_chunk_size, (double **)nullptr,
 			logp,threads, pool,detector_N, 

--- a/include/gwat/mcmc_gw.h
+++ b/include/gwat/mcmc_gw.h
@@ -96,6 +96,14 @@ struct MCMC_modification_struct
 	// Not as trivial as you might think!
 	// Default: 20 Hz.
 	double f_ref = 20.;
+
+	// ---- Temperature ladder settings ----
+	// The maximum temperature below Inf
+	double Tmax = 100.;
+	// The dampening time. If left at 0, BayesShip sets it to burnIterations/8.
+	double t0 = 0.;
+	// Timescale of adjustments
+	double nu = 100.;
 };
 
 static MCMC_modification_struct *mcmc_mod_struct;

--- a/include/gwat/mcmc_gw_extended.h
+++ b/include/gwat/mcmc_gw_extended.h
@@ -66,11 +66,19 @@ std::string MCMC_prep_params_v2(double *param, double *temp_params, gen_params_b
 
 //double MCMC_likelihood_wrapper_v2(bayesship::positionInfo *pos, int chainID, bayesship::bayesshipSampler *sampler ,void *userParameters);
 
+struct temp_settings
+{
+	double Tmax = 100.;
+	double t0 = 0.;
+	double nu = 100.;
+} default_temp_set;
+
 bayesship::bayesshipSampler *  PTMCMC_MH_dynamic_PT_alloc_uncorrelated_GW_v2(
 	int dimension,
 	int independentSamples,
 	int ensembleSize,
 	int ensembleN,
+	temp_settings* temp_set,
 	bayesship::positionInfo *initialPosition,
 	bayesship::positionInfo **initialEnsemble,
 	double swapProb,

--- a/include/gwat/mcmc_gw_extended.h
+++ b/include/gwat/mcmc_gw_extended.h
@@ -64,21 +64,12 @@ void RJPTMCMC_method_specific_prep_v2(std::string generation_method, int dimensi
 
 std::string MCMC_prep_params_v2(double *param, double *temp_params, gen_params_base<double> *gen_params, int dimension, std::string generation_method, MCMC_modification_struct *mod_struct, bool intrinsic, double gmst);
 
-//double MCMC_likelihood_wrapper_v2(bayesship::positionInfo *pos, int chainID, bayesship::bayesshipSampler *sampler ,void *userParameters);
-
-struct temp_settings
-{
-	double Tmax = 100.;
-	double t0 = 0.;
-	double nu = 100.;
-} default_temp_set;
 
 bayesship::bayesshipSampler *  PTMCMC_MH_dynamic_PT_alloc_uncorrelated_GW_v2(
 	int dimension,
 	int independentSamples,
 	int ensembleSize,
 	int ensembleN,
-	temp_settings* temp_set,
 	bayesship::positionInfo *initialPosition,
 	bayesship::positionInfo **initialEnsemble,
 	double swapProb,
@@ -88,7 +79,6 @@ bayesship::bayesshipSampler *  PTMCMC_MH_dynamic_PT_alloc_uncorrelated_GW_v2(
 	bool writePriorData,
 	int batchSize,
 	double **priorRanges,
-	//double(*log_prior)(bayesship::positionInfo *pos, int chainID,bayesship::bayesshipSampler *sampler, void *userParameters),
 	bayesship::probabilityFn *lp,
 	int numThreads,
 	bool pool,

--- a/include/gwat/standardPriorLibrary.h
+++ b/include/gwat/standardPriorLibrary.h
@@ -31,7 +31,13 @@ struct priorData
 	double ctheta1_prior[2];
 	double ctheta2_prior[2];
 	double phi1_prior[2];
-	double phi2_prior[2];	
+	double phi2_prior[2];
+	double ciota_bounds[2] {-1., 1.};
+	double PSI_bounds[2] {0, M_PI};
+	double phi_ref_bounds[2] {0, 2*M_PI};
+	// Bounds to the left and right of T_merger.
+	// The zeroth element is subtracted from T_merger, the first element is added.
+	double T_merger_bounds[2] {0.1, 0.1};
 };
 
 bool tidal_love_boundary_violation(double q,double lambda_s);

--- a/src/mcmc_gw_extended.cpp
+++ b/src/mcmc_gw_extended.cpp
@@ -1221,6 +1221,7 @@ bayesship::bayesshipSampler *  PTMCMC_MH_dynamic_PT_alloc_uncorrelated_GW_v2(
 	int independentSamples,
 	int ensembleSize,
 	int ensembleN,
+	temp_settings* temp_set,
 	bayesship::positionInfo *initialPosition,
 	bayesship::positionInfo **initialEnsemble,
 	double swapProb,
@@ -1438,6 +1439,9 @@ bayesship::bayesshipSampler *  PTMCMC_MH_dynamic_PT_alloc_uncorrelated_GW_v2(
 	sampler->initialPositionEnsemble = initialEnsemble;
 	sampler->ignoreExistingCheckpoint = ignoreExistingCheckpoint;
 	sampler->restrictSwapTemperatures = restrictSwapTemperatures;
+	sampler->t0 = temp_set->t0;
+	sampler->nu = temp_set->nu;
+	sampler->Tmax = temp_set->Tmax;
 
 	//Testing
 	//sampler->coldOnlyStorage = false;

--- a/src/mcmc_gw_extended.cpp
+++ b/src/mcmc_gw_extended.cpp
@@ -1221,7 +1221,6 @@ bayesship::bayesshipSampler *  PTMCMC_MH_dynamic_PT_alloc_uncorrelated_GW_v2(
 	int independentSamples,
 	int ensembleSize,
 	int ensembleN,
-	temp_settings* temp_set,
 	bayesship::positionInfo *initialPosition,
 	bayesship::positionInfo **initialEnsemble,
 	double swapProb,
@@ -1439,9 +1438,9 @@ bayesship::bayesshipSampler *  PTMCMC_MH_dynamic_PT_alloc_uncorrelated_GW_v2(
 	sampler->initialPositionEnsemble = initialEnsemble;
 	sampler->ignoreExistingCheckpoint = ignoreExistingCheckpoint;
 	sampler->restrictSwapTemperatures = restrictSwapTemperatures;
-	sampler->t0 = temp_set->t0;
-	sampler->nu = temp_set->nu;
-	sampler->Tmax = temp_set->Tmax;
+	sampler->t0 = mod_struct->t0;
+	sampler->nu = mod_struct->nu;
+	sampler->Tmax = mod_struct->Tmax;
 
 	//Testing
 	//sampler->coldOnlyStorage = false;

--- a/src/standardPriorLibrary.cpp
+++ b/src/standardPriorLibrary.cpp
@@ -452,10 +452,11 @@ double logPriorStandard_P::eval(bayesship::positionInfo *position, int chainID)
 	//###########
 	if ((pos[0])<PD->RA_bounds[0] || (pos[0])>PD->RA_bounds[1]){ return a;}//RA
 	if ((pos[1])<PD->sinDEC_bounds[0] || (pos[1])>PD->sinDEC_bounds[1]){return a;}//sinDEC
-	if ((pos[2])<0 || (pos[2])>M_PI){return a;}//PSI
-	if ((pos[3])<-1 || (pos[3])>1){return a;}//cos \iota
-	if ((pos[4])<0 || (pos[4])>2*M_PI){return a;}//phiRef
-	if( pos[5] < (PD->T_merger - .1) || pos[5] > (PD->T_merger + .1)) { return a; }
+	if ((pos[2])<PD->PSI_bounds[0] || (pos[2])>PD->PSI_bounds[1]){return a;}//PSI
+	if ((pos[3])<PD->ciota_bounds[0] || (pos[3])>PD->ciota_bounds[1]){return a;}//cos \iota
+	if ((pos[4])<PD->phi_ref_bounds[0] || (pos[4])>PD->phi_ref_bounds[1]){return a;}//phiRef
+	// T_merger
+	if( pos[5] < (PD->T_merger - PD->T_merger_bounds[0]) || pos[5] > (PD->T_merger + PD->T_merger_bounds[1])) { return a; }
 	if (std::exp(pos[6])<PD->DL_prior[0] || std::exp(pos[6])>PD->DL_prior[1]){return a;}//DL
 	if ((pos[9])<PD->a1_prior[0] || (pos[9])>PD->a1_prior[1]){return a;}//mag1
 	if ((pos[10])<PD->a2_prior[0] || (pos[10])>PD->a2_prior[1]){return a;}//mag2


### PR DESCRIPTION
Temperature settings for BayesShip can now be passed through `MCMC_modification_struct` (see struct definition). `logPriorStandard_P` has more modifiable priors now as well.